### PR TITLE
fix: reorder COPY command in Dockerfile for clarity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ COPY requirements.txt .
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy application code
-COPY . .
-
 # Pre-download BGE-M3 model into the image so it's not fetched at runtime
 RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('BAAI/bge-m3')"
+
+# Copy application code
+COPY . .
 
 # Expose port
 EXPOSE 8000


### PR DESCRIPTION
closed #70

### 설명
- docker build에서 model 다운로드가 캐싱이 안 되는 문제를 해결했습니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
